### PR TITLE
clean repo without losing .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "react-scripts start",
     "start-dev": "react-scripts -r @cypress/instrument-cra start",
+    "clean-project": "mv .env .hold-this-env && git clean -fXd && mv .hold-this-env .env",
     "cypress": "npx cypress run",
     "dev": "start-test 3000 cypress",
     "build": "react-scripts build",


### PR DESCRIPTION
Non-breaking utility script to help developer workflow.

 Temporarily renames .env, removes files that are in .gitignore (node_modules), and restores the .env file.

```
(𝝺). yarn clean-project               
yarn run v1.22.4
$ mv .env .hold-this-env && git clean -fXd && mv .hold-this-env .env
Removing node_modules/
Removing yarn.lock
Done in 1.77s.
```
Then you can run yarn install and download fresh packages:
`yarn clean-project && yarn install && yarn start`